### PR TITLE
Position header permalinks in left gutter, w/ responsive breakpoint.

### DIFF
--- a/themes/aframe/source/css/secondary.styl
+++ b/themes/aframe/source/css/secondary.styl
@@ -359,15 +359,13 @@ p [href*=github][href*="/blob/"]:only-child,
     h5[id],
     h6[id]
         cursor pointer
-        margin-left -1.5rem
         position relative
-        text-indent 1.5rem
         &:before
             border-bottom 1px solid #fff
             color #ccc
             content ""
             height 100%
-            left 0
+            left -1.5rem
             position absolute
             text-indent 0
             width 1.5rem
@@ -450,6 +448,15 @@ p [href*=github][href*="/blob/"]:only-child,
 
         .github-file-link
             margin-left 0
+
+    .content--docs
+        h2[id],
+        h3[id],
+        h4[id],
+        h5[id],
+        h6[id]
+            &:before
+                left: -1rem
 
     .section-title
         position relative


### PR DESCRIPTION
Fixes a small alignment issue on long headers with permalinks.

(screenshots on iPhone 6, screen @ 320px width)

### Before:
![img_3913](https://cloud.githubusercontent.com/assets/1848368/11888158/b65f0f46-a508-11e5-9988-e94ef342e977.PNG)

### After:
![img_3916](https://cloud.githubusercontent.com/assets/1848368/11888161/bac14310-a508-11e5-8976-3c7bd5b7e17f.PNG)

### After (with anchor):
![img_3917](https://cloud.githubusercontent.com/assets/1848368/11888182/fd074472-a508-11e5-96f2-72c5b3ab4890.PNG)
